### PR TITLE
full font awesome name

### DIFF
--- a/library.js
+++ b/library.js
@@ -70,7 +70,7 @@
         name: 'steam',
         url: '/auth/steam',
         callbackURL: '/auth/steam/callback',
-        icon: 'steam',
+        icon: 'fa-steam',
         scope: 'user:username'
       });
     }


### PR DESCRIPTION
Fix deprecation warning from NodeBB 0.5 :

> [plugins] Deprecation notice: SSO plugins should now pass in the full fontawesome icon name (e.g. "fa-facebook-o"). Please update the following plugins:
> - steam
