### PR TITLE
fix "missing API key" exception in passport-steam

### DIFF
--- a/library.js
+++ b/library.js
@@ -36,7 +36,8 @@
     if (meta.config['social:steam:apikey']) {
       passport.use(new passportSteam({
         returnURL: module.parent.require('nconf').get('url') + '/auth/steam/callback',
-        realm: module.parent.require('nconf').get('url')
+        realm: module.parent.require('nconf').get('url'),
+        apiKey: meta.config['social:steam:apikey']
       }, function(identifier, profile, done) {
         process.nextTick(function () {
           // As Steam Passport does't not provide the username, steamid and avatar information, we have to get from Steam API using http get request.


### PR DESCRIPTION
Got the following exception: 

```
Error: invalid or missing API key
    at new steam (/var/www/forum/nodebb-dev/node_modules/nodebb-plugin-sso-steam/node_modules/passport-steam/node_modules/steam-web/lib/steam.js:20:80)
    at new Strategy (/var/www/forum/nodebb-dev/node_modules/nodebb-plugin-sso-steam/node_modules/passport-steam/lib/passport-steam/strategy.js:49:17)
    at Object.Steam.getStrategy (/var/www/forum/nodebb-dev/node_modules/nodebb-plugin-sso-steam/library.js:37:20)
    at /var/www/forum/nodebb-dev/src/plugins.js:377:32
    at /var/www/forum/nodebb-dev/node_modules/async/lib/async.js:272:13
    at iterate (/var/www/forum/nodebb-dev/node_modules/async/lib/async.js:149:13)
    at Object.async.eachSeries (/var/www/forum/nodebb-dev/node_modules/async/lib/async.js:165:9)
    at Object.async.reduce (/var/www/forum/nodebb-dev/node_modules/async/lib/async.js:271:15)
    at Object.Plugins.fireHook (/var/www/forum/nodebb-dev/src/plugins.js:371:12)
    at /var/www/forum/nodebb-dev/src/routes/authentication.js:140:12

```

passport-steam wants to have the apikey in its options parameter since https://github.com/liamcurry/passport-steam/commit/c872805826e5e72f7548bb2e532ec86dec995654 , unless you specify `profile:false`
