### PR TITLE
Fix unreliable config

### DIFF
--- a/library.js
+++ b/library.js
@@ -132,15 +132,15 @@
   };
 
   function renderAdmin(req, res, callback) {
-		res.render('sso/steam/admin', {});
-	}
+    res.render('sso/steam/admin', {});
+  }
 
   Steam.init = function(data, callback) {
-		data.router.get('/admin/steam', data.middleware.admin.buildHeader, renderAdmin);
-		data.router.get('/api/admin/steam', renderAdmin);
+    data.router.get('/admin/steam', data.middleware.admin.buildHeader, renderAdmin);
+    data.router.get('/api/admin/steam', renderAdmin);
 
-        callback();
-	};
+    callback();
+  };
 
   module.exports = Steam;
 }(module));


### PR DESCRIPTION
Get config/settings when it is actually needed, like it's done in [sso-twitter](https://github.com/julianlam/nodebb-plugin-sso-twitter/blob/master/library.js#L36) and [sso-facebook](https://github.com/julianlam/nodebb-plugin-sso-facebook/blob/master/library.js#L36).

For months, I've been wondering why on my forum instance, sometimes the steam login icon disappeared on the `/login` page, while the twitter plugin happily continued to work.
I think I've found the problem :)

`static:app_load` is the hook for _re_loading _routes_. It seems to be executed on start, and on reload, but _not_ when something within the forum dies (exception being thrown somewhere) and the forum quietly restarts in the background.
